### PR TITLE
Add windows packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,16 @@ Once your cmake project is configured
 #include <qbjs_deserializer/qbjs_deserializer.hpp>
 
 // In your code...
-// 1. Use your favorite file reading API to read the content of the file you want
+// 1. Use your favorite API to read the content of the file you want
 // to deserialize and get it as a vector of uint8_t
 std::vector<uint8_t> fileBinaryContent = // ...
 
 // qbjs_deserializer_cxx transforms qbjs_deserializer's errors into std::exception with a message
 try {
-    const rust::String deserialized_qbjs = qbjs_deserializer::deserialize_to_json(fileBinaryContent);
+    std::string deserialized_qbjs; // Resulting std::string needs to be created on C++ side.
+    qbjs_deserializer::deserialize_to_json(fileBinaryContent, deserialized_qbjs);
 
-    if (deserialized_qbjs.empty()) {
-        return -1;
-    }
-
-    // 2. Give this string to your favorite JSON parsing API. You may have to convert it to std string first.
-    const std::string deserialized_qbjs_as_std_string(deserialized_qbjs);
-    // JSON parsing calls...
+    // 2. Give this string to your favorite JSON parsing API.
 
     // 3. Work on your data...
 }
@@ -94,3 +89,11 @@ qbjs_deserializer_cxx checks qbjs_deserializer errors and returns an exception w
 | [qbjs::read::ReadError::InvalidNumberDataRange](https://docs.rs/qbjs_deserializer/0.0.2/qbjs_deserializer/read/enum.ReadError.html#variant.InvalidNumberDataRange) | Attempted to read a number value but reached end of slice |
 | [qbjs::read::ReadError::InvalidLatin1StringDataRange](https://docs.rs/qbjs_deserializer/0.0.2/qbjs_deserializer/read/enum.ReadError.html#variant.InvalidLatin1StringDataRange) | Attempted to read a Latin 1 string (key or value) but reached end of slice |
 | [qbjs::read::ReadError::InvalidUtf16StringDataRange](https://docs.rs/qbjs_deserializer/0.0.2/qbjs_deserializer/read/enum.ReadError.html#variant.InvalidUtf16StringDataRange) | Attempted to read a UTF-16 string (key or value) but reached end of slice |
+
+## Tested platform
+The C++ packaging has been tested (built once with conan with a successful test package) locally on the following platforms:
+| OS | C++ compiler | Rust compiler version |
+| - | - | - |
+| Windows 10 | MSVC Community 2022 | 1.64 |
+| Ubuntu 20.04 | gcc-9.4 | 1.64 |
+| MacOS 12 | Appleclang 13 | 1.64 |

--- a/cpp_packaging/CMakeLists.txt
+++ b/cpp_packaging/CMakeLists.txt
@@ -4,6 +4,27 @@ project(qbjs_deserializer VERSION 0.0.2)
 
 find_package(Threads REQUIRED)
 
+if (UNIX AND NOT APPLE)
+    set(QBJS_DESERIALIZER_PLATFORM_SPECIFIC_LINK_LIBRARIES
+        dl
+    )
+elseif (MSVC)
+    set(QBJS_DESERIALIZER_PLATFORM_SPECIFIC_LINK_LIBRARIES
+        userenv
+        ws2_32
+        bcrypt
+    )
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+if (MSVC)
+    set(LIB_FILE_PREFIX )
+    set(LIB_FILE_EXTENSION lib)
+else()
+    set(LIB_FILE_PREFIX lib)
+    set(LIB_FILE_EXTENSION a)
+endif()
+
 add_library(qbjs_deserializer SHARED
             ${CMAKE_SOURCE_DIR}/qbjs_deserializer/include/qbjs_deserializer/qbjs_deserializer.hpp
             ${CMAKE_SOURCE_DIR}/qbjs_deserializer/src/qbjs_deserializer.cpp
@@ -13,19 +34,15 @@ set_property(TARGET qbjs_deserializer PROPERTY CXX_STANDARD 17)
 set_property(TARGET qbjs_deserializer PROPERTY CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set_property(TARGET qbjs_deserializer PROPERTY CMAKE_SKIP_RPATH TRUE)
 
-if (UNIX)
-set(QBJS_DESERIALIZER_EXTRA_LINK_LIBRARIES
-    dl
-)
-endif()
-
 target_link_libraries(qbjs_deserializer
+    PUBLIC
+    ${QBJS_DESERIALIZER_PLATFORM_SPECIFIC_LINK_LIBRARIES}
     PRIVATE
-    ${CMAKE_SOURCE_DIR}/qbjs_deserializer/lib/libqbjs_deserializer_cxx.a
-    ${CMAKE_SOURCE_DIR}/qbjs_deserializer/lib/libcxxbridge1.a
     Threads::Threads
-    ${QBJS_DESERIALIZER_EXTRA_LINK_LIBRARIES}
+    ${CMAKE_SOURCE_DIR}/qbjs_deserializer/lib/${LIB_FILE_PREFIX}qbjs_deserializer_cxx.${LIB_FILE_EXTENSION}
+    ${CMAKE_SOURCE_DIR}/qbjs_deserializer/lib/${LIB_FILE_PREFIX}cxxbridge1.${LIB_FILE_EXTENSION}
 )
+
 
 install(TARGETS qbjs_deserializer
     EXPORT qbjs_deserializerTargets

--- a/cpp_packaging/conanfile.py
+++ b/cpp_packaging/conanfile.py
@@ -55,17 +55,25 @@ class qbjsDeserializerConan(ConanFile):
         )
 
         qbjs_deserializer_target_release_path = "{}/target/release/".format(rust_brige_crate_root)
+
+        if self.settings.compiler == "Visual Studio":
+            lib_prefix = ""
+            lib_extension = "lib"
+        else:
+            lib_prefix = "lib"
+            lib_extension = "a"
+
         tools.rename(
-            "{}/libqbjs_deserializer_cxx.a".format(qbjs_deserializer_target_release_path),
-            "{}/lib/libqbjs_deserializer_cxx.a".format(qbjs_deserializer_root),
+            "{0}/{1}qbjs_deserializer_cxx.{2}".format(qbjs_deserializer_target_release_path, lib_prefix, lib_extension),
+            "{0}/lib/{1}qbjs_deserializer_cxx.{2}".format(qbjs_deserializer_root, lib_prefix, lib_extension),
         )
 
         # Use glob to find libcxxbridge1.a because the output folder starting with cxx- has a hash and can't be hardcoded
         for libcxxbridge1 in glob.glob(
-            "{}/build/cxx-*/out/libcxxbridge1.a".format(qbjs_deserializer_target_release_path)
+            "{0}/build/cxx-*/out/{1}cxxbridge1.{2}".format(qbjs_deserializer_target_release_path, lib_prefix, lib_extension)
         ):
             tools.rename(
-                libcxxbridge1, "{}/lib/libcxxbridge1.a".format(qbjs_deserializer_root)
+                libcxxbridge1, "{0}/lib/{1}cxxbridge1.{2}".format(qbjs_deserializer_root, lib_prefix, lib_extension)
             )
 
         cmake = CMake(self, parallel=True)
@@ -80,7 +88,10 @@ class qbjsDeserializerConan(ConanFile):
             dst="include/qbjs_deserializer/",
             keep_path=False,
         )
-        self.copy("build/libqbjs_deserializer.so", src=".", dst="lib/", keep_path=False)
+        # if self.settings.compiler == "Visual Studio":
+        #     self.copy("qbjs_deserializer/lib/*.lib", src=".", dst="lib/", keep_path=False)
+        # else:
+        #     self.copy("build/libqbjs_deserializer.so", src=".", dst="lib/", keep_path=False)
 
     def package_info(self):
         self.cpp_info.includedirs = ["include"]

--- a/cpp_packaging/test_package/conanfile.py
+++ b/cpp_packaging/test_package/conanfile.py
@@ -11,6 +11,7 @@ class qbjsDeserializerTestConan(ConanFile):
         self.copy("*.dll", src="bin", dst=os.path.join("install", "bin"))
         self.copy("*.dylib*", src="lib", dst=os.path.join("install", "lib"))
         self.copy("*.so*", src="lib", dst=os.path.join("install", "lib"))
+        self.copy("*.lib*", src="lib", dst=os.path.join("install", "lib"))
 
     def build(self):
         cmake = CMake(self)

--- a/cpp_packaging/test_package/src/main.cpp
+++ b/cpp_packaging/test_package/src/main.cpp
@@ -44,8 +44,8 @@ int main(int argc, char** argv) {
 
   try {
     const auto qbjsFileContent = load_file(qbjsFilename);
-    const auto jsonContent =
-        qbjs_deserializer::deserialize_to_json(qbjsFileContent);
+    std::string outputJsonContent;
+    qbjs_deserializer::deserialize_to_json(qbjsFileContent, outputJsonContent);
 
     std::ofstream outputJsonFile(outputJsonFilename);
 
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
                                std::strerror(errno));
     }
 
-    outputJsonFile << std::string(jsonContent) << std::endl;
+    outputJsonFile << outputJsonContent << std::endl;
     outputJsonFile.close();
   } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
@@ -68,12 +68,12 @@ int main(int argc, char** argv) {
   try {
     const auto invalidHeaderQbjsFileContent =
         load_file(invalidHeaderQbjsFilename);
-    const auto jsonContent =
-        qbjs_deserializer::deserialize_to_json(invalidHeaderQbjsFileContent);
+    std::string outputJsonContent;
+    qbjs_deserializer::deserialize_to_json(invalidHeaderQbjsFileContent, outputJsonContent);
 
     // Should never be reached as we try to trigger an invalid qbjs header
     // exception
-    std::cout << std::string(jsonContent) << std::endl;
+    std::cout << outputJsonContent << std::endl;
   } catch (const std::exception& e) {
     std::ofstream outputTextFile(outputTextFilename);
 


### PR DESCRIPTION
Changed API of the C++ bridge: new take a reference to a std::string in which the deserialized qbjs content is copied. The original idea of returning a rust::String didn't work because of some missing destructor symbols on Windows, so we use this alternative. In a way it is better as the C++ only handle C++ types now.